### PR TITLE
Adicionado a página com o mapa das biblioteas

### DIFF
--- a/bibliotecas.html
+++ b/bibliotecas.html
@@ -1,0 +1,3 @@
+Lista e mapa das Bibliotecas em Portugal:
+<p>
+<iframe style="width: 80vw; height: 50vh; border: none;" src="https://query.wikidata.org/embed.html#%23Map%20of%20libraries%20in%20Portugal%0ASELECT%20%3FitemLabel%20%3Fgeo%20WHERE%20%7B%0A%20%20%3Fitem%20wdt%3AP31%2Fwdt%3AP279%2a%20wd%3AQ7075%3B%0A%20%20%20%20%20%20%20%20wdt%3AP625%20%3Fgeo%20.%0A%20%20%3Fitem%20wdt%3AP17%20wd%3AQ45%20.%0A%20%20%09SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22pt%2Cen%22%20%7D%20.%0A%7D" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups" ></iframe>


### PR DESCRIPTION
Este PR adiciona ao repositório o ficheiro `bibliotecas.html`, que neste momento é pouco mais do que uma página que faz
render da sequinte query no wikidata:
```
SELECT ?itemLabel ?geo WHERE {
  ?item wdt:P31/wdt:P279* wd:Q7075;
        wdt:P625 ?geo .
  ?item wdt:P17 wd:Q45 .
  	SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en" } .
}
```
Com isto, podemos ver um mapa das bibliotecas em Portugal, e também
pode servir de template para o mapa dos outros equipamentos que
pretendemos mapear.

---

Pode já ser visto em acção em https://marado.github.io/ate-onde-chega-cultura/bibliotecas.html
Se este PR for merged, depois também se pode configurar para o mapa ser servido daqui (isto é, https://interruptorpt.github.io/ate-onde-chega-cultura/bibliotecas.html ).