### PR TITLE
make wikidata queries human readable

### DIFF
--- a/bibliotecas.html
+++ b/bibliotecas.html
@@ -1,3 +1,25 @@
-Lista e mapa das Bibliotecas em Portugal:
-<p>
-<iframe style="width: 80vw; height: 50vh; border: none;" src="https://query.wikidata.org/embed.html#%23Map%20of%20libraries%20in%20Portugal%0ASELECT%20%3FitemLabel%20%3Fgeo%20WHERE%20%7B%0A%20%20%3Fitem%20wdt%3AP31%2Fwdt%3AP279%2a%20wd%3AQ7075%3B%0A%20%20%20%20%20%20%20%20wdt%3AP625%20%3Fgeo%20.%0A%20%20%3Fitem%20wdt%3AP17%20wd%3AQ45%20.%0A%20%20%09SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22pt%2Cen%22%20%7D%20.%0A%7D" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups" ></iframe>
+<!DOCTYPE html>
+
+<body>
+  Lista e mapa das Bibliotecas em Portugal:
+  <p>
+    <iframe id="wikidataframe" style="width: 80vw; height: 50vh; border: none;" referrerpolicy="origin"
+      sandbox="allow-scripts allow-same-origin allow-popups"></iframe>
+
+    <script>
+      var wikidataQuery = `
+#Map of libraries in Portugal
+SELECT ?itemLabel ?geo WHERE {
+  ?item wdt:P31/wdt:P279* wd:Q7075;
+        wdt:P625 ?geo .
+  ?item wdt:P17 wd:Q45 .
+  	SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en" } .
+}
+`
+      var urlPrefix = "https://query.wikidata.org/embed.html#"
+      var frame = document.getElementById("wikidataframe")
+      frame.src = urlPrefix + encodeURI(wikidataQuery)
+
+    </script>
+  </p>
+</body>

--- a/cinemas.html
+++ b/cinemas.html
@@ -1,5 +1,25 @@
-Lista e mapa dos Cinemas em Portugal:
-<p>
-    <iframe style="width: 80vw; height: 50vh; border: none;"
-            src="https://query.wikidata.org/embed.html#%23Map%20of%20libraries%20in%20Portugal%0ASELECT%20%3FitemLabel%20%3Fgeo%20WHERE%20%7B%0A%20%20%3Fitem%20(wdt%3AP31%2F(wdt%3AP279*))%20wd%3AQ41253%3B%0A%20%20%20%20wdt%3AP625%20%3Fgeo%3B%0A%20%20%20%20wdt%3AP17%20wd%3AQ45.%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22pt%2Cen%22.%20%7D%0A%7D"
-            referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups"></iframe>
+<!DOCTYPE html>
+
+<body>
+  Lista e mapa dos Cinemas em Portugal:
+  <p>
+    <iframe id="wikidataframe" style="width: 80vw; height: 50vh; border: none;" referrerpolicy="origin"
+      sandbox="allow-scripts allow-same-origin allow-popups"></iframe>
+
+    <script>
+      var wikidataQuery = `
+# List of cinemas in Portugal
+SELECT ?itemLabel ?geo WHERE {
+  ?item (wdt:P31/(wdt:P279*)) wd:Q41253;
+    wdt:P625 ?geo;
+    wdt:P17 wd:Q45.
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en". }
+}
+`
+      var urlPrefix = "https://query.wikidata.org/embed.html#"
+      var frame = document.getElementById("wikidataframe")
+      frame.src = urlPrefix + encodeURI(wikidataQuery)
+
+    </script>
+  </p>
+</body>

--- a/museus.html
+++ b/museus.html
@@ -1,5 +1,25 @@
-Lista e mapa dos Museus em Portugal:
-<p>
-    <iframe style="width: 80vw; height: 50vh; border: none;"
-            src="https://query.wikidata.org/embed.html#%23Map%20of%20libraries%20in%20Portugal%0ASELECT%20%3FitemLabel%20%3Fgeo%20WHERE%20%7B%0A%20%20%3Fitem%20(wdt%3AP31%2F(wdt%3AP279*))%20wd%3AQ33506%3B%0A%20%20%20%20wdt%3AP625%20%3Fgeo%3B%0A%20%20%20%20wdt%3AP17%20wd%3AQ45.%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22pt%2Cen%22.%20%7D%0A%7D"
-            referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups"></iframe>
+<!DOCTYPE html>
+
+<body>
+  Lista e mapa dos Museus em Portugal:
+  <p>
+    <iframe id="wikidataframe" style="width: 80vw; height: 50vh; border: none;" referrerpolicy="origin"
+      sandbox="allow-scripts allow-same-origin allow-popups"></iframe>
+
+    <script>
+      var wikidataQuery = `
+# List of museums in Portugal
+SELECT ?itemLabel ?geo WHERE {
+  ?item (wdt:P31/(wdt:P279*)) wd:Q33506;
+    wdt:P625 ?geo;
+    wdt:P17 wd:Q45.
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en". }
+}
+`
+      var urlPrefix = "https://query.wikidata.org/embed.html#"
+      var frame = document.getElementById("wikidataframe")
+      frame.src = urlPrefix + encodeURI(wikidataQuery)
+
+    </script>
+  </p>
+</body>

--- a/teatros.html
+++ b/teatros.html
@@ -1,4 +1,25 @@
-Lista e mapa dos teatros em Portugal:
-<p>
+<!DOCTYPE html>
 
-<iframe style="width: 80vw; height: 50vh; border: none;" src="https://query.wikidata.org/embed.html#SELECT%20%3FitemLabel%20%3Fgeo%20WHERE%20%7B%0A%20%20%3Fitem%20wdt%3AP31%2Fwdt%3AP279*%20wd%3AQ24354%3B%0A%20%20%20%20%20%20%20%20wdt%3AP625%20%3Fgeo%20.%0A%20%20%3Fitem%20wdt%3AP17%20wd%3AQ45%20.%0A%20%20%09SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22pt%2Cen%22%20%7D%20.%0A%7D" referrerpolicy="origin" sandbox="allow-scripts allow-same-origin allow-popups"></iframe>
+<body>
+  Lista e mapa dos teatros em Portugal:
+  <p>
+    <iframe id="wikidataframe" style="width: 80vw; height: 50vh; border: none;" referrerpolicy="origin"
+      sandbox="allow-scripts allow-same-origin allow-popups"></iframe>
+
+    <script>
+      var wikidataQuery = `
+# List of theaters in Portugal
+SELECT ?itemLabel ?geo WHERE {
+  ?item wdt:P31/wdt:P279* wd:Q24354;
+        wdt:P625 ?geo .
+  ?item wdt:P17 wd:Q45 .
+  	SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en" } .
+}
+`
+      var urlPrefix = "https://query.wikidata.org/embed.html#"
+      var frame = document.getElementById("wikidataframe")
+      frame.src = urlPrefix + encodeURI(wikidataQuery)
+
+    </script>
+  </p>
+</body>


### PR DESCRIPTION
Acho que fica mais fácil manter isto a longo prazo se as queries à wikidata estiverem legíveis.
A única coisa a mudar caso se queira acrescentar mais dados é apenas a variável wikidataQuery.

É suposto não haver nenhuma alteração a nível do utilizador. Parece estar a funcionar:
http://github.carreira.pw/ate-onde-chega-cultura/bibliotecas
http://github.carreira.pw/ate-onde-chega-cultura/cinemas
http://github.carreira.pw/ate-onde-chega-cultura/museus
http://github.carreira.pw/ate-onde-chega-cultura/teatros


nota: não sei se funciona em todos os browsers :D 