### PR TITLE
Melhoria da formatação das queries Wikidata

### DIFF
--- a/bibliotecas.html
+++ b/bibliotecas.html
@@ -24,14 +24,15 @@
 
           <script>
             var wikidataQuery = `
-#Map of libraries in Portugal
-SELECT ?itemLabel ?geo WHERE {
-  ?item wdt:P31/wdt:P279* wd:Q7075;
-        wdt:P625 ?geo .
-  ?item wdt:P17 wd:Q45 .
-  	SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en" } .
-}
-`
+              # List of libraries in Portugal
+              SELECT ?itemLabel ?geo WHERE {
+                ?item  wdt:P31/wdt:P279*  wd:Q7075.  # Item is an instance or subclass of Library (Q7075)
+                ?item  wdt:P625           ?geo.      # Store item's geographic coordinates in the ?geo variable
+                ?item  wdt:P17            wd:Q45.    # Item's country is Portugal
+
+                SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en" }.
+              }
+              `
             var urlPrefix = "https://query.wikidata.org/embed.html#"
             var frame = document.getElementById("wikidataframe")
             frame.src = urlPrefix + encodeURI(wikidataQuery)

--- a/cinemas.html
+++ b/cinemas.html
@@ -24,14 +24,15 @@
 
           <script>
             var wikidataQuery = `
-        # List of cinemas in Portugal
-        SELECT ?itemLabel ?geo WHERE {
-          ?item (wdt:P31/(wdt:P279*)) wd:Q41253;
-            wdt:P625 ?geo;
-            wdt:P17 wd:Q45.
-          SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en". }
-        }
-        `
+              # List of cinemas in Portugal
+              SELECT ?itemLabel ?geo WHERE {
+                ?item  wdt:P31/wdt:P279*  wd:Q41253.  # Item is an instance or subclass of Cinema (Q41253)
+                ?item  wdt:P625           ?geo.       # Store item's geographic coordinates in the ?geo variable
+                ?item  wdt:P17            wd:Q45.     # Item's country is Portugal
+
+                SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en". }
+              }
+              `
             var urlPrefix = "https://query.wikidata.org/embed.html#"
             var frame = document.getElementById("wikidataframe")
             frame.src = urlPrefix + encodeURI(wikidataQuery)

--- a/galerias.html
+++ b/galerias.html
@@ -24,14 +24,15 @@
 
           <script>
             var wikidataQuery = `
-        # List of art galleries in Portugal
-        SELECT ?itemLabel ?geo WHERE {
-          ?item wdt:P31/wdt:P279* wd:Q1007870;
-                wdt:P625 ?geo .
-          ?item wdt:P17 wd:Q45 .
-          SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en" } .
-        }
-        `
+              # List of art galleries in Portugal
+              SELECT ?itemLabel ?geo WHERE {
+                ?item  wdt:P31/wdt:P279*  wd:Q1007870.  # Item is an instance or subclass of Art gallery (Q1007870)
+                ?item  wdt:P625           ?geo.         # Store item's geographic coordinates in the ?geo variable
+                ?item  wdt:P17            wd:Q45.       # Item's country is Portugal
+
+                SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en" }.
+              }
+              `
             var urlPrefix = "https://query.wikidata.org/embed.html#"
             var frame = document.getElementById("wikidataframe")
             frame.src = urlPrefix + encodeURI(wikidataQuery)

--- a/museus.html
+++ b/museus.html
@@ -24,14 +24,15 @@
 
           <script>
             var wikidataQuery = `
-        # List of museums in Portugal
-        SELECT ?itemLabel ?geo WHERE {
-          ?item (wdt:P31/(wdt:P279*)) wd:Q33506;
-            wdt:P625 ?geo;
-            wdt:P17 wd:Q45.
-          SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en". }
-        }
-        `
+              # List of museums in Portugal
+              SELECT ?itemLabel ?geo WHERE {
+                ?item  wdt:P31/wdt:P279*  wd:Q33506.  # Item is an instance or subclass of Museum (Q33506)
+                ?item  wdt:P625           ?geo.       # Store item's geographic coordinates in the ?geo variable
+                ?item  wdt:P17            wd:Q45.     # Item's country is Portugal
+
+                SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en" }.
+              }
+              `
             var urlPrefix = "https://query.wikidata.org/embed.html#"
             var frame = document.getElementById("wikidataframe")
             frame.src = urlPrefix + encodeURI(wikidataQuery)

--- a/recintos.html
+++ b/recintos.html
@@ -24,14 +24,15 @@
 
           <script>
             var wikidataQuery = `
-        # List of show venues in Portugal
-        SELECT ?itemLabel ?geo WHERE {
-          ?item wdt:P31/wdt:P279* wd:Q18674739;
-                wdt:P625 ?geo .
-          ?item wdt:P17 wd:Q45 .
-          SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en" } .
-        }
-        `
+              # List of show venues in Portugal
+              SELECT ?itemLabel ?geo WHERE {
+                ?item  wdt:P31/wdt:P279*  wd:Q18674739.  # Item is an instance or subclass of Show venue (Q18674739)
+                ?item  wdt:P625           ?geo.          # Store item's geographic coordinates in the ?geo variable
+                ?item  wdt:P17            wd:Q45.        # Item's country is Portugal
+
+                SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en" }.
+              }
+              `
             var urlPrefix = "https://query.wikidata.org/embed.html#"
             var frame = document.getElementById("wikidataframe")
             frame.src = urlPrefix + encodeURI(wikidataQuery)

--- a/teatros.html
+++ b/teatros.html
@@ -24,14 +24,15 @@
 
           <script>
             var wikidataQuery = `
-        # List of theaters in Portugal
-        SELECT ?itemLabel ?geo WHERE {
-          ?item wdt:P31/wdt:P279* wd:Q24354;
-                wdt:P625 ?geo .
-          ?item wdt:P17 wd:Q45 .
-            SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en" } .
-        }
-        `
+              # List of theaters in Portugal
+              SELECT ?itemLabel ?geo WHERE {
+                ?item  wdt:P31/wdt:P279*  wd:Q24354.  # Item is an instance or subclass of Theater (Q24354)
+                ?item  wdt:P625           ?geo.       # Store item's geographic coordinates in the ?geo variable
+                ?item  wdt:P17            wd:Q45.     # Item's country is Portugal
+
+                SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en" }.
+              }
+              `
             var urlPrefix = "https://query.wikidata.org/embed.html#"
             var frame = document.getElementById("wikidataframe")
             frame.src = urlPrefix + encodeURI(wikidataQuery)


### PR DESCRIPTION
- Melhorada indentação para condizer com o código circundante
- Acrescentada documentação aos filtros (triplos semânticos)
- Espacamento e uso de sintaxe completa (sujeito, predicado, objeto) para facilitar a leitura e compreensão
- Padronização da pontuação em todas as queries