### PR TITLE
Mostrar queries como mapas

### DIFF
--- a/bibliotecas.html
+++ b/bibliotecas.html
@@ -24,7 +24,8 @@
 
           <script>
             var wikidataQuery = `
-              # List of libraries in Portugal
+              # Map of libraries in Portugal
+              #defaultView:Map
               SELECT ?itemLabel ?geo WHERE {
                 ?item  wdt:P31/wdt:P279*  wd:Q7075.  # Item is an instance or subclass of Library (Q7075)
                 ?item  wdt:P625           ?geo.      # Store item's geographic coordinates in the ?geo variable

--- a/cinemas.html
+++ b/cinemas.html
@@ -24,7 +24,8 @@
 
           <script>
             var wikidataQuery = `
-              # List of cinemas in Portugal
+              # Map of cinemas in Portugal
+              #defaultView:Map
               SELECT ?itemLabel ?geo WHERE {
                 ?item  wdt:P31/wdt:P279*  wd:Q41253.  # Item is an instance or subclass of Cinema (Q41253)
                 ?item  wdt:P625           ?geo.       # Store item's geographic coordinates in the ?geo variable

--- a/galerias.html
+++ b/galerias.html
@@ -24,7 +24,8 @@
 
           <script>
             var wikidataQuery = `
-              # List of art galleries in Portugal
+              # Map of art galleries in Portugal
+              #defaultView:Map
               SELECT ?itemLabel ?geo WHERE {
                 ?item  wdt:P31/wdt:P279*  wd:Q1007870.  # Item is an instance or subclass of Art gallery (Q1007870)
                 ?item  wdt:P625           ?geo.         # Store item's geographic coordinates in the ?geo variable

--- a/museus.html
+++ b/museus.html
@@ -24,7 +24,8 @@
 
           <script>
             var wikidataQuery = `
-              # List of museums in Portugal
+              # Map of museums in Portugal
+              #defaultView:Map
               SELECT ?itemLabel ?geo WHERE {
                 ?item  wdt:P31/wdt:P279*  wd:Q33506.  # Item is an instance or subclass of Museum (Q33506)
                 ?item  wdt:P625           ?geo.       # Store item's geographic coordinates in the ?geo variable

--- a/recintos.html
+++ b/recintos.html
@@ -24,7 +24,8 @@
 
           <script>
             var wikidataQuery = `
-              # List of show venues in Portugal
+              # Map of show venues in Portugal
+              #defaultView:Map
               SELECT ?itemLabel ?geo WHERE {
                 ?item  wdt:P31/wdt:P279*  wd:Q18674739.  # Item is an instance or subclass of Show venue (Q18674739)
                 ?item  wdt:P625           ?geo.          # Store item's geographic coordinates in the ?geo variable

--- a/teatros.html
+++ b/teatros.html
@@ -24,7 +24,8 @@
 
           <script>
             var wikidataQuery = `
-              # List of theaters in Portugal
+              # Map of theaters in Portugal
+              #defaultView:Map
               SELECT ?itemLabel ?geo WHERE {
                 ?item  wdt:P31/wdt:P279*  wd:Q24354.  # Item is an instance or subclass of Theater (Q24354)
                 ?item  wdt:P625           ?geo.       # Store item's geographic coordinates in the ?geo variable


### PR DESCRIPTION
Em vez dos embeds do resultado das queries Wikidata começarem por mostrar os dados como tabelas que têm que ser trocadas para a vista de mapa manualmente, agora os resultados aparecem automaticamente como mapas.