### PR TITLE
Incluir items Wikidata nos resultados das queries

### DIFF
--- a/bibliotecas.html
+++ b/bibliotecas.html
@@ -26,7 +26,7 @@
             var wikidataQuery = `
               # Map of libraries in Portugal
               #defaultView:Map
-              SELECT ?itemLabel ?geo WHERE {
+              SELECT ?item ?itemLabel ?geo WHERE {
                 ?item  wdt:P31/wdt:P279*  wd:Q7075.  # Item is an instance or subclass of Library (Q7075)
                 ?item  wdt:P625           ?geo.      # Store item's geographic coordinates in the ?geo variable
                 ?item  wdt:P17            wd:Q45.    # Item's country is Portugal

--- a/cinemas.html
+++ b/cinemas.html
@@ -26,7 +26,7 @@
             var wikidataQuery = `
               # Map of cinemas in Portugal
               #defaultView:Map
-              SELECT ?itemLabel ?geo WHERE {
+              SELECT ?item ?itemLabel ?geo WHERE {
                 ?item  wdt:P31/wdt:P279*  wd:Q41253.  # Item is an instance or subclass of Cinema (Q41253)
                 ?item  wdt:P625           ?geo.       # Store item's geographic coordinates in the ?geo variable
                 ?item  wdt:P17            wd:Q45.     # Item's country is Portugal

--- a/galerias.html
+++ b/galerias.html
@@ -26,7 +26,7 @@
             var wikidataQuery = `
               # Map of art galleries in Portugal
               #defaultView:Map
-              SELECT ?itemLabel ?geo WHERE {
+              SELECT ?item ?itemLabel ?geo WHERE {
                 ?item  wdt:P31/wdt:P279*  wd:Q1007870.  # Item is an instance or subclass of Art gallery (Q1007870)
                 ?item  wdt:P625           ?geo.         # Store item's geographic coordinates in the ?geo variable
                 ?item  wdt:P17            wd:Q45.       # Item's country is Portugal

--- a/mapa.html
+++ b/mapa.html
@@ -35,7 +35,7 @@
 
       async function loadCategoryLayer(category) {
         const url = `https://query.wikidata.org/bigdata/namespace/wdq/sparql?format=json&query=${encodeURIComponent(`
-          SELECT ?itemLabel ?geo WHERE {
+          SELECT ?item ?itemLabel ?geo WHERE {
             # Item is an instance or subclass of the given category
             ?item  wdt:P31/wdt:P279*  wd:${category.subclass}.
             # Store item's geographic coordinates in the ?geo variable

--- a/mapa.html
+++ b/mapa.html
@@ -20,6 +20,7 @@
         { name: "Bibliotecas", icon: "local_library",     subclass: "Q7075" },
         { name: "Cinemas",     icon: "movie",             subclass: "Q41253" },
         { name: "Galerias",    icon: "filter_frames",     subclass: "Q1007870" },
+        { name: "Monumentos",  icon: "account_balance",   subclass: "Q4989906" },
         { name: "Museus",      icon: "museum",            subclass: "Q33506" },
         { name: "Recintos",    icon: "workspaces_filled", subclass: "Q18674739" },
         { name: "Teatros",     icon: "theater_comedy",    subclass: "Q24354" },

--- a/monumentos.html
+++ b/monumentos.html
@@ -26,7 +26,7 @@
             var wikidataQuery = `
               # Map of monuments in Portugal
               #defaultView:Map
-              SELECT ?itemLabel ?geo WHERE {
+              SELECT ?item ?itemLabel ?geo WHERE {
                 ?item  wdt:P31/wdt:P279*  wd:Q4989906.  # Item is an instance or subclass of Monument (Q4989906)
                 ?item  wdt:P625           ?geo.         # Store item's geographic coordinates in the ?geo variable
                 ?item  wdt:P17            wd:Q45.       # Item's country is Portugal

--- a/museus.html
+++ b/museus.html
@@ -26,7 +26,7 @@
             var wikidataQuery = `
               # Map of museums in Portugal
               #defaultView:Map
-              SELECT ?itemLabel ?geo WHERE {
+              SELECT ?item ?itemLabel ?geo WHERE {
                 ?item  wdt:P31/wdt:P279*  wd:Q33506.  # Item is an instance or subclass of Museum (Q33506)
                 ?item  wdt:P625           ?geo.       # Store item's geographic coordinates in the ?geo variable
                 ?item  wdt:P17            wd:Q45.     # Item's country is Portugal

--- a/recintos.html
+++ b/recintos.html
@@ -26,7 +26,7 @@
             var wikidataQuery = `
               # Map of show venues in Portugal
               #defaultView:Map
-              SELECT ?itemLabel ?geo WHERE {
+              SELECT ?item ?itemLabel ?geo WHERE {
                 ?item  wdt:P31/wdt:P279*  wd:Q18674739.  # Item is an instance or subclass of Show venue (Q18674739)
                 ?item  wdt:P625           ?geo.          # Store item's geographic coordinates in the ?geo variable
                 ?item  wdt:P17            wd:Q45.        # Item's country is Portugal

--- a/teatros.html
+++ b/teatros.html
@@ -26,7 +26,7 @@
             var wikidataQuery = `
               # Map of theaters in Portugal
               #defaultView:Map
-              SELECT ?itemLabel ?geo WHERE {
+              SELECT ?item ?itemLabel ?geo WHERE {
                 ?item  wdt:P31/wdt:P279*  wd:Q24354.  # Item is an instance or subclass of Theater (Q24354)
                 ?item  wdt:P625           ?geo.       # Store item's geographic coordinates in the ?geo variable
                 ?item  wdt:P17            wd:Q45.     # Item's country is Portugal


### PR DESCRIPTION
- Adicionados monumentos ao mapa combinado (fixes #41).
- Adicionado item Wikidata aos resultados das queries.
  Isto permite, nas visualizações do próprio Wikidata, clicar no link para visitar a página Wikidata correspondente ao item.