### PR TITLE
Ordenar resultados das queries Wikidata

### DIFF
--- a/wikidata-queries/bibliotecas.query
+++ b/wikidata-queries/bibliotecas.query
@@ -7,3 +7,4 @@ SELECT ?item ?itemLabel ?geo WHERE {
 
   SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en" }.
 }
+ORDER BY ?itemLabel

--- a/wikidata-queries/cinemas.query
+++ b/wikidata-queries/cinemas.query
@@ -7,3 +7,4 @@ SELECT ?item ?itemLabel ?geo WHERE {
 
   SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en". }
 }
+ORDER BY ?itemLabel

--- a/wikidata-queries/galerias.query
+++ b/wikidata-queries/galerias.query
@@ -7,3 +7,4 @@ SELECT ?item ?itemLabel ?geo WHERE {
 
   SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en" }.
 }
+ORDER BY ?itemLabel

--- a/wikidata-queries/monumentos.query
+++ b/wikidata-queries/monumentos.query
@@ -7,3 +7,4 @@ SELECT ?item ?itemLabel ?geo WHERE {
 
   SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en" }.
 }
+ORDER BY ?itemLabel

--- a/wikidata-queries/museus.query
+++ b/wikidata-queries/museus.query
@@ -7,3 +7,4 @@ SELECT ?item ?itemLabel ?geo WHERE {
 
   SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en" }.
 }
+ORDER BY ?itemLabel

--- a/wikidata-queries/recintos.query
+++ b/wikidata-queries/recintos.query
@@ -7,3 +7,4 @@ SELECT ?item ?itemLabel ?geo WHERE {
 
   SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en" }.
 }
+ORDER BY ?itemLabel

--- a/wikidata-queries/teatros.query
+++ b/wikidata-queries/teatros.query
@@ -7,3 +7,4 @@ SELECT ?item ?itemLabel ?geo WHERE {
 
   SERVICE wikibase:label { bd:serviceParam wikibase:language "pt,en" }.
 }
+ORDER BY ?itemLabel


### PR DESCRIPTION
Isto permite que a ordem dos resultados seja dererminística, impedindo diffs desnecessariamente grandes quando se faz o updade da cache de dados estáticos (como aconteceu em f14a8c67a), permitindo assim perceber realmente o que mudou desde a última sincronização.