### PR TITLE
Flutter snap

### DIFF
--- a/build_snap.sh
+++ b/build_snap.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+# This script will just issue the necessary commands for you to build the snap.
+#
+# Why is this script needed:
+# 1. The Flutter app code is not on the root directory of the repository
+# 2. It assists all users to generate a snap packge for the flutter app, even if
+# they don't know how to generate a snap package.
+#
+# What should users expect of it:
+# 1. It will only work on a system that is already snap enabled, it will fail
+# otherwise. And the user is expected to enable snap packages support by
+# him/herself. Details on how to do it can be found at: https://snapcraft.io/docs/installing-snapd
+# 2. If snapcraft is not installed it will be installed.
+
+
+# TODO:
+# 1. Output errros and warnings correctly to STDERR
+# 2. Refactor to use functions
+# X-1. Test!!!
+# X. Get more items for the TODO list and improve it
+
+# Possible exit status for the script:
+# 0 - Succeed generating packge
+# 1 - OS is currenlty not snap enabled
+# 2 - Snapcraft is not installed and failed to install
+# 3 - Failed changing into the directory that is the Flutter app base path
+# 4 - Snapcraft exited with a non 0 exit status
+
+echo "INFO: Checking if the Operating System is snap package enabled"
+which snap
+IS_SNAP_ENABLED=$? # if 0 yes 1 is no
+
+if [[ ${IS_SNAP_ENABLED} -eq 1 ]]
+then
+  echo "ERROR: Your Operating System is not snap enabled."
+  printf "WARN: To be able to generate a snap you need to have snap support and snapcraft installed.\nYou can learn how to enable snap packages support on your\nOperating System at: https://snapcraft.io/docs/installing-snapd\n\n"
+  exit 1;
+fi
+
+
+which snapcraft
+IS_SNAPCRAFT_INSTALLED=$?
+
+if [[ ${IS_SNAPCRAFT_INSTALLED} -eq 1 ]]
+then
+  echo "WARN: Snapcraft is not installed, will install now"
+  sudo snap install snapcraft --classic
+  INSTALATION_SUCCEED=$?
+  if [[ ${INSTALATION_SUCCEED} -ne 0 ]]
+  then
+    echo "ERROR: Snapcraft installation failed!"
+    echo "WARN: Stopping snap package generation procedure"
+    exit 2
+  fi
+fi
+
+# make sure we are within the repository directory, otherwise guess it by the
+# path of $0
+REPOSITORY_BASE_PATH=$(readlink ${0%$BASE})
+
+# change directory into the Fluter app base path
+FLUTTER_APP_BASE_PATH=${REPOSITORY_BASE_PATH}/mobileapp
+if [[ -xd ${FLUTTER_APP_BASE_APP} ]]
+then
+  cd ${FLUTTER_APP_BASE_APP}
+  if [[ $? -ne 0 ]]
+  then 
+    echo "ERROR: Failed changing directory into ${FLUTTER_APP_BASE_APP}"
+    exit 3
+  fi
+fi
+
+# Generate the snap package
+snapcraft
+if [[ $? -ne 0]]
+then
+  echo "ERROR: Failed generating snap package"
+  exit 4
+fi
+
+exit 0

--- a/mobileapp/snap/snapcraft.yaml
+++ b/mobileapp/snap/snapcraft.yaml
@@ -1,0 +1,17 @@
+name: my-snap-name # you probably want to 'snapcraft register <name>'
+base: core18 # the base snap is the execution environment for this snap
+version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
+summary: Single-line elevator pitch for your amazing snap # 79 char long summary
+description: |
+  This is my-snap's description. You have a paragraph or two to tell the
+  most important story about your snap. Keep it under 100 words though,
+  we live in tweetspace and your description wants to look good in the snap
+  store.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: devmode # use 'strict' once you have the right plugs and slots
+
+parts:
+  my-part:
+    # See 'snapcraft plugins'
+    plugin: nil

--- a/mobileapp/snap/snapcraft.yaml
+++ b/mobileapp/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: my-snap-name # you probably want to 'snapcraft register <name>'
+name: cultura # you probably want to 'snapcraft register <name>'
 base: core18 # the base snap is the execution environment for this snap
 version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
 summary: Single-line elevator pitch for your amazing snap # 79 char long summary
@@ -12,6 +12,13 @@ grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: devmode # use 'strict' once you have the right plugs and slots
 
 parts:
-  my-part:
+  mobileapp:
     # See 'snapcraft plugins'
-    plugin: nil
+    plugin: flutter
+    source: .
+    flutter-target: lib/main.dart
+
+apps:
+  mobileapp:
+    command: mobileapp
+    extensions: [flutter-dev]


### PR DESCRIPTION
Para resolver o #26, segue o commit inicial do snapcraft.yaml para gerar o snap da aplicação em flutter, e de um script em bash, para automatizar o processo de ter snapcraft e de passos que têm de ser tomados antes de o correr por a aplicação Flutter não estar na raiz do repositório.