### PR TITLE
Prevent duplicate entries in the data

### DIFF
--- a/static-data/bibliotecas.json
+++ b/static-data/bibliotecas.json
@@ -27,36 +27,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-9.145715 38.723544)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q85726963"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Q85726963"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-9.14291 38.717755)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q85726964"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Q85726964"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-9.14291 38.717755)"
                 },
                 "item": {
@@ -209,38 +179,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Biblioteca Joanina",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-8.4265 40.2071)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q1773229"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Biblioteca Joanina",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-8.427775 41.547995)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q18500432"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Biblioteca L\u00facio Craveiro da Silva",
                     "xml:lang": "pt"
                 }
             },
@@ -561,22 +499,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Biblioteca Municipal Bento de Jesus Cara\u00e7a",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-8.681163 39.233882)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q23890843"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Biblioteca Municipal Braamcamp Freire",
                     "xml:lang": "pt"
                 }
             },
@@ -4136,22 +4058,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-8.542833333 40.928138888)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q18500442"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Biblioteca Municipal de Santa Maria da Feira",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-8.542849 40.928201)"
                 },
                 "item": {
@@ -4648,38 +4554,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-8.826788 41.691459)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q17318051"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Biblioteca Municipal de Viana do Castelo",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-8.826788 41.691459)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q17318051"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Biblioteca Municipal de Viana do Castelo",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-8.987831 38.952456)"
                 },
                 "item": {
@@ -5080,22 +4954,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-9.112968 38.763757)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q71848091"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Biblioteca Municipal dos Olivais",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-7.647694 37.122361)"
                 },
                 "item": {
@@ -5121,22 +4979,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Biblioteca M\u00e1rio Sottomayor Cardia",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-9.152573 38.75108)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q245966"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Biblioteca Nacional de Portugal",
                     "xml:lang": "pt"
                 }
             },
@@ -5272,22 +5114,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-8.601528 41.146044)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q630086"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Biblioteca P\u00fablica Municipal do Porto",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-9.125531 38.727362)"
                 },
                 "item": {
@@ -5340,22 +5166,6 @@
                 },
                 "item": {
                     "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q100999021"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Biblioteca P\u00fablica de \u00c9vora",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-9.125531 38.727362)"
-                },
-                "item": {
-                    "type": "uri",
                     "value": "http://www.wikidata.org/entity/Q100999027"
                 },
                 "itemLabel": {
@@ -5393,22 +5203,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Biblioteca P\u00fablica e Arquivo de Angra do Hero\u00edsmo",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-9.32528 38.67856)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q59621112"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Biblioteca Teresa e Alexandre Soares dos Santos",
                     "xml:lang": "pt"
                 }
             },

--- a/static-data/cinemas.json
+++ b/static-data/cinemas.json
@@ -956,22 +956,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-9.1562045 38.7188922)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q37813250"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Jardim Cinema",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-9.145665 38.733333)"
                 },
                 "item": {

--- a/static-data/monumentos.json
+++ b/static-data/monumentos.json
@@ -1272,22 +1272,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-8.762328 41.578323)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q9616854"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Anta da Portelagem e Mamoas do R\u00e1pido",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-7.202996 40.612362)"
                 },
                 "item": {
@@ -1736,22 +1720,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-7.804215 40.453569)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q20170765"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Anta de Curral dos Mouros",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-7.331637 38.988175)"
                 },
                 "item": {
@@ -1864,22 +1832,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-8.017118 38.894147)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q570542"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Anta de Pavia",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-7.72385 40.84459)"
                 },
                 "item": {
@@ -1921,22 +1873,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Anta de Silvadas",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-8.129480361 38.524589538)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q2378035"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Anta de S\u00e3o Brissos",
                     "xml:lang": "pt"
                 }
             },
@@ -2824,22 +2760,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-9.266565 38.770547)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q47353823"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Antas de Belas",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-7.565548 40.657514)"
                 },
                 "item": {
@@ -3617,22 +3537,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Calv\u00e1rio de Castelo Mendo",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-7.519202 40.645371)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q67779114"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Calv\u00e1rio em Algodres",
                     "xml:lang": "pt"
                 }
             },
@@ -6040,38 +5944,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-16.907677 32.648986)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q67322077"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Chafariz do Largo do Chafariz",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-16.907677 32.648986)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q67322077"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Chafariz do Largo do Chafariz",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-9.154089 38.719943)"
                 },
                 "item": {
@@ -6424,7 +6296,7 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-8.39475256 41.68896217)"
+                    "value": "Point(-8.393894195 41.689399719)"
                 },
                 "item": {
                     "type": "uri",
@@ -7240,22 +7112,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-8.197116 41.749561)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q10261935"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Cruzeiro de Campo do Ger\u00eas",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-7.493269 39.827697)"
                 },
                 "item": {
@@ -7640,38 +7496,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-8.46643 41.572112)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q96777056"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Cruzeiro de Pan\u00f3ias",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-8.46643 41.572112)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q96777056"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Cruzeiro de Pan\u00f3ias",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-8.3571 41.427011111)"
                 },
                 "item": {
@@ -7825,22 +7649,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Cruzeiro de Santa Marta",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-9.182083 38.701876)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q65946079"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Cruzeiro de Santo Amaro",
                     "xml:lang": "pt"
                 }
             },
@@ -8113,22 +7921,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Cruzeiro de Ten\u00f5es",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-8.478753 41.557831)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q39713625"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Cruzeiro de Tib\u00e3es",
                     "xml:lang": "pt"
                 }
             },
@@ -8552,22 +8344,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-8.417672157 41.557735443)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q102390201"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Cruzeiro do Senhor das \u00c2nsias",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-7.807844 41.092728)"
                 },
                 "item": {
@@ -8673,38 +8449,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Cruzeiro dos Centen\u00e1rios (Castelo Mendo)",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-6.948493 40.594772)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q67355935"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Cruzeiro dos Centen\u00e1rios (Castelo Mendo)",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-8.284705555 41.446483333)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q96831326"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Cruzeiro dos Centen\u00e1rios de Guimar\u00e3es",
                     "xml:lang": "pt"
                 }
             },
@@ -9576,22 +9320,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-9.382116 39.134865)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q76970645"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Est\u00e1tua de Antero de Quental",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-7.350263 40.777753)"
                 },
                 "item": {
@@ -9880,54 +9608,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-8.37791667 41.55484167)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q10277573"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Est\u00e1tua de S\u00e3o Longuinho",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-8.37791667 41.55484167)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q10277573"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Est\u00e1tua de S\u00e3o Longuinho",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-6.715986 41.341065)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q69351635"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Est\u00e1tua de Trindade Coelho",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-6.715986 41.341065)"
                 },
                 "item": {
@@ -10097,22 +9777,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Est\u00e1tua do marco",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-9.13648 38.707539)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q18476235"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Est\u00e1tua equestre de D. Jos\u00e9 I",
                     "xml:lang": "pt"
                 }
             },
@@ -10824,22 +10488,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-7.166044 38.878898)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q70081427"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Fonte da Miseric\u00f3rdia",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-9.391045 38.795774)"
                 },
                 "item": {
@@ -11457,22 +11105,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Fonte de S\u00e3o Louren\u00e7o",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-7.1622 38.880173)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q70082931"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Fonte de S\u00e3o Louren\u00e7o (Elvas)",
                     "xml:lang": "pt"
                 }
             },
@@ -12232,38 +11864,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-8.199537 39.464235)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q85918055"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Homenagem ao Actor Taborda",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-8.198718 39.461248)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q85914960"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Homenagem ao General Avelar Machado",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-8.198718 39.461248)"
                 },
                 "item": {
@@ -12433,22 +12033,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "L\u00e1pide do Munic\u00edpio de Portalegre",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-8.213846 38.651039)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q66813745"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "L\u00e1pide do chafariz de Montemor-o-Novo",
                     "xml:lang": "pt"
                 }
             },
@@ -15000,22 +14584,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-8.61071111 41.14969167)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q2649664"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Monumento Almeida Garrett",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-9.32104 38.677103)"
                 },
                 "item": {
@@ -15025,22 +14593,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Monumento Comemorativo dos 200 anos do Col\u00e9gio Militar",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-8.684880555 37.103547222)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q97164311"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Monumento Liberdade, Di\u00e1logo e Democracia",
                     "xml:lang": "pt"
                 }
             },
@@ -15112,22 +14664,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-9.258503 38.750995)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q100621721"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Monumento a D. Maria I",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-7.645766 39.3051)"
                 },
                 "item": {
@@ -15153,38 +14689,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Monumento a D. Pedro IV",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-8.61136 41.1465)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q11783"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Monumento a D. Pedro IV",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-9.004007663 39.051052626)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q102175396"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Monumento a Dami\u00e3o de G\u00f3is",
                     "xml:lang": "pt"
                 }
             },
@@ -15873,22 +15377,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Padr\u00e3o da Ponte do Esp\u00edrito Santo",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-8.30099 41.44151)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q10343502"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Padr\u00e3o de D. Jo\u00e3o I",
                     "xml:lang": "pt"
                 }
             },

--- a/static-data/museus.json
+++ b/static-data/museus.json
@@ -59,38 +59,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-7.793638888 41.519361111)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q96305198"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Museu da Escola (Ribeira de Pena)",
-                    "xml:lang": "en"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-7.846916666 41.472305555)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q96306182"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Museu do Volfr\u00e2mio",
-                    "xml:lang": "en"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-7.846916666 41.472305555)"
                 },
                 "item": {
@@ -260,22 +228,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Cadeia da Rela\u00e7\u00e3o",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-16.335726 33.059417)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q9698061"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Casa Colombo",
                     "xml:lang": "pt"
                 }
             },
@@ -747,22 +699,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-16.912583333 32.650166666)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q54823828"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Casa-Museu Frederico de Freitas",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-9.105919 38.79316)"
                 },
                 "item": {
@@ -891,22 +827,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-9.235674 38.756643)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q17167622"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Centro Ci\u00eancia Viva da Amadora",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-8.32384722 39.49482778)"
                 },
                 "item": {
@@ -948,22 +868,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Centro Internacional das Artes Jos\u00e9 de Guimar\u00e3es",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-8.432311 40.201401)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q76324836"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Centro Interpretativo do Mosteiro de Santa Clara-a-Velha",
                     "xml:lang": "pt"
                 }
             },
@@ -1867,22 +1771,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-8.52744 41.35107)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q16609740"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Museu Ferrovi\u00e1rio de Lousado",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-8.45869 40.65361)"
                 },
                 "item": {
@@ -2267,22 +2155,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-8.474394 39.464288)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q5365136"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Museu Nacional Ferrovi\u00e1rio",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-7.90694444 38.57194444)"
                 },
                 "item": {
@@ -2315,22 +2187,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-7.91102778 40.66015278)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q5612742"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Museu Nacional Gr\u00e3o Vasco",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-8.57668333 41.14340833)"
                 },
                 "item": {
@@ -2340,38 +2196,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Museu Nacional da Imprensa, Jornais e Artes Gr\u00e1ficas",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-9.161813 38.704626)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q212459"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Museu Nacional de Arte Antiga",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-9.161813 38.704626)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q212459"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Museu Nacional de Arte Antiga",
                     "xml:lang": "pt"
                 }
             },
@@ -2475,22 +2299,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-8.62155 41.14770833)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q1141468"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Museu Nacional de Soares dos Reis",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-9.11389 38.7244)"
                 },
                 "item": {
@@ -2516,22 +2324,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Museu Nacional do Teatro e da Dan\u00e7a",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-9.164985 38.775163)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q9047155"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Museu Nacional do Traje",
                     "xml:lang": "pt"
                 }
             },
@@ -3307,38 +3099,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-16.91031 32.648915)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q1954374"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Museu de Fotografia da Madeira",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-16.91031 32.648915)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q1954374"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Museu de Fotografia da Madeira",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-9.38999 38.798113)"
                 },
                 "item": {
@@ -3579,22 +3339,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-8.481807 42.078613)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q28679539"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Museu do Alvarinho",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-9.3425 38.836944444)"
                 },
                 "item": {
@@ -3796,22 +3540,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Museu do Combatente",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-7.112861111 41.079888888)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q50414505"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Museu do C\u00f4a",
                     "xml:lang": "pt"
                 }
             },
@@ -4100,38 +3828,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Museu dos T\u00eaxteis MUTEX",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-7.571021 39.750273)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q85006712"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Museu dos T\u00eaxteis MUTEX",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-16.906944444 32.648055555)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q10338552"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "N\u00facleo Museol\u00f3gico da Cidade do A\u00e7\u00facar",
                     "xml:lang": "pt"
                 }
             },

--- a/static-data/recintos.json
+++ b/static-data/recintos.json
@@ -396,54 +396,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-8.667564 40.600519)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q76182899"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Casa da Cultura de \u00cdlhavo",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-8.667564 40.600519)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q76182899"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Casa da Cultura de \u00cdlhavo",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-8.630711111 41.158886111)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q917274"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Casa da M\u00fasica",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-8.630711111 41.158886111)"
                 },
                 "item": {
@@ -485,22 +437,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Casa das Mudas",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-7.674589 39.65514)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q84612535"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Casa de Artes e Cultura do Tejo",
                     "xml:lang": "pt"
                 }
             },
@@ -588,38 +524,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-9.382441 38.803388)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q9723382"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Centro Cultural Olga Cadaval",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-9.382441 38.803388)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q9723382"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Centro Cultural Olga Cadaval",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-8.7412 41.60653)"
                 },
                 "item": {
@@ -661,22 +565,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Centro Cultural da Malaposta",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-9.207778 38.695556)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q1054277"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Centro Cultural de Bel\u00e9m",
                     "xml:lang": "pt"
                 }
             },
@@ -1116,22 +1004,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-9.14016667 38.71675)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q1108805"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Coliseu dos Recreios",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-16.93222222 32.63527778)"
                 },
                 "item": {
@@ -1413,6 +1285,22 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "C\u00e2mara Municipal do Barreiro",
+                    "xml:lang": "pt"
+                }
+            },
+            {
+                "geo": {
+                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
+                    "type": "literal",
+                    "value": "Point(-9.129397576 38.716501736)"
+                },
+                "item": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q105485854"
+                },
+                "itemLabel": {
+                    "type": "literal",
+                    "value": "Damas",
                     "xml:lang": "pt"
                 }
             },
@@ -2828,22 +2716,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-9.14527778 38.7425)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q784174"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Pra\u00e7a de Touros do Campo Pequeno",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-9.134583333 39.407694444)"
                 },
                 "item": {
@@ -2885,6 +2757,22 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Ru\u00ednas do Teatro Romano",
+                    "xml:lang": "pt"
+                }
+            },
+            {
+                "geo": {
+                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
+                    "type": "literal",
+                    "value": "Point(-9.35714295 38.689352826)"
+                },
+                "item": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q105405110"
+                },
+                "itemLabel": {
+                    "type": "literal",
+                    "value": "Sociedade Musical Uni\u00e3o Paredense",
                     "xml:lang": "pt"
                 }
             },
@@ -3308,22 +3196,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-25.66625 37.7418)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q10378870"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Teatro Micaelense",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-16.91142778 32.64700833)"
                 },
                 "item": {
@@ -3397,38 +3269,6 @@
                 "itemLabel": {
                     "type": "literal",
                     "value": "Teatro Nacional S\u00e3o Jo\u00e3o",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-8.607465 41.144626)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q1109226"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Teatro Nacional S\u00e3o Jo\u00e3o",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-9.141666666 38.709444444)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q1146936"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Teatro Nacional de S\u00e3o Carlos",
                     "xml:lang": "pt"
                 }
             },

--- a/static-data/teatros.json
+++ b/static-data/teatros.json
@@ -1036,38 +1036,6 @@
                 "geo": {
                     "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
                     "type": "literal",
-                    "value": "Point(-8.607465 41.144626)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q1109226"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Teatro Nacional S\u00e3o Jo\u00e3o",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
-                    "value": "Point(-9.141666666 38.709444444)"
-                },
-                "item": {
-                    "type": "uri",
-                    "value": "http://www.wikidata.org/entity/Q1146936"
-                },
-                "itemLabel": {
-                    "type": "literal",
-                    "value": "Teatro Nacional de S\u00e3o Carlos",
-                    "xml:lang": "pt"
-                }
-            },
-            {
-                "geo": {
-                    "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
-                    "type": "literal",
                     "value": "Point(-9.141666666 38.709444444)"
                 },
                 "item": {

--- a/wikidata-queries/bibliotecas.query
+++ b/wikidata-queries/bibliotecas.query
@@ -1,6 +1,6 @@
 # Map of libraries in Portugal
 #defaultView:Map
-SELECT ?item ?itemLabel ?geo WHERE {
+SELECT DISTINCT ?item ?itemLabel ?geo WHERE {
   ?item  wdt:P31/wdt:P279*  wd:Q7075.  # Item is an instance or subclass of Library (Q7075)
   ?item  wdt:P625           ?geo.      # Store item's geographic coordinates in the ?geo variable
   ?item  wdt:P17            wd:Q45.    # Item's country is Portugal

--- a/wikidata-queries/cinemas.query
+++ b/wikidata-queries/cinemas.query
@@ -1,6 +1,6 @@
 # Map of cinemas in Portugal
 #defaultView:Map
-SELECT ?item ?itemLabel ?geo WHERE {
+SELECT DISTINCT ?item ?itemLabel ?geo WHERE {
   ?item  wdt:P31/wdt:P279*  wd:Q41253.  # Item is an instance or subclass of Cinema (Q41253)
   ?item  wdt:P625           ?geo.       # Store item's geographic coordinates in the ?geo variable
   ?item  wdt:P17            wd:Q45.     # Item's country is Portugal

--- a/wikidata-queries/galerias.query
+++ b/wikidata-queries/galerias.query
@@ -1,6 +1,6 @@
 # Map of art galleries in Portugal
 #defaultView:Map
-SELECT ?item ?itemLabel ?geo WHERE {
+SELECT DISTINCT ?item ?itemLabel ?geo WHERE {
   ?item  wdt:P31/wdt:P279*  wd:Q1007870.  # Item is an instance or subclass of Art gallery (Q1007870)
   ?item  wdt:P625           ?geo.         # Store item's geographic coordinates in the ?geo variable
   ?item  wdt:P17            wd:Q45.       # Item's country is Portugal

--- a/wikidata-queries/monumentos.query
+++ b/wikidata-queries/monumentos.query
@@ -1,6 +1,6 @@
 # Map of monuments in Portugal
 #defaultView:Map
-SELECT ?item ?itemLabel ?geo WHERE {
+SELECT DISTINCT ?item ?itemLabel ?geo WHERE {
   ?item  wdt:P31/wdt:P279*  wd:Q4989906.  # Item is an instance or subclass of Monument (Q4989906)
   ?item  wdt:P625           ?geo.         # Store item's geographic coordinates in the ?geo variable
   ?item  wdt:P17            wd:Q45.       # Item's country is Portugal

--- a/wikidata-queries/museus.query
+++ b/wikidata-queries/museus.query
@@ -1,6 +1,6 @@
 # Map of museums in Portugal
 #defaultView:Map
-SELECT ?item ?itemLabel ?geo WHERE {
+SELECT DISTINCT ?item ?itemLabel ?geo WHERE {
   ?item  wdt:P31/wdt:P279*  wd:Q33506.  # Item is an instance or subclass of Museum (Q33506)
   ?item  wdt:P625           ?geo.       # Store item's geographic coordinates in the ?geo variable
   ?item  wdt:P17            wd:Q45.     # Item's country is Portugal

--- a/wikidata-queries/recintos.query
+++ b/wikidata-queries/recintos.query
@@ -1,6 +1,6 @@
 # Map of show venues in Portugal
 #defaultView:Map
-SELECT ?item ?itemLabel ?geo WHERE {
+SELECT DISTINCT ?item ?itemLabel ?geo WHERE {
   ?item  wdt:P31/wdt:P279*  wd:Q18674739.  # Item is an instance or subclass of Show venue (Q18674739)
   ?item  wdt:P625           ?geo.          # Store item's geographic coordinates in the ?geo variable
   ?item  wdt:P17            wd:Q45.        # Item's country is Portugal

--- a/wikidata-queries/teatros.query
+++ b/wikidata-queries/teatros.query
@@ -1,6 +1,6 @@
 # Map of theaters in Portugal
 #defaultView:Map
-SELECT ?item ?itemLabel ?geo WHERE {
+SELECT DISTINCT ?item ?itemLabel ?geo WHERE {
   ?item  wdt:P31/wdt:P279*  wd:Q24354.  # Item is an instance or subclass of Theater (Q24354)
   ?item  wdt:P625           ?geo.       # Store item's geographic coordinates in the ?geo variable
   ?item  wdt:P17            wd:Q45.     # Item's country is Portugal


### PR DESCRIPTION
At the moment, the queries made to wikidata are retrieving some duplicate entries, as you can see in the static data files.
I've just added a `DISTINCT` statement to the queries and updated the data