### PR TITLE
Preview link on pullrequest

### DIFF
--- a/.github/workflows/preview_link_on_pullrequest.yml
+++ b/.github/workflows/preview_link_on_pullrequest.yml
@@ -1,0 +1,44 @@
+name: Publish a preview link to Github Pages on Pull Requests
+
+on:
+  pull_request:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get some variables
+        id: extract_vars
+        shell: bash
+        run: |
+          echo "##[set-output name=pr_number;]$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")"
+          echo "##[set-output name=baseurl;]$(echo -n "https://interruptorpt.github.io/ate-onde-chega-cultura" )"
+          echo "##[set-output name=previewpath;]$(echo -n "prev-link/pr" )"
+
+      - name: Replace absolute links
+        shell: bash
+        run: |
+          find * -type f | xargs sed -i 's@${{steps.extract_vars.outputs.baseurl}}/@./@g'
+
+      - name: Deploy a preview link
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          enable_jekyll: true
+          publish_dir: .
+          destination_dir: ./${{ steps.extract_vars.outputs.previewpath }}/${{ steps.extract_vars.outputs.pr_number }}
+          keep_files: true
+
+      - name: Comment on Pull Request
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "Olá 👋. Estamos muito agradecidos pela tua colaboração.\nEnquanto aguardas a aprovação deste Pull Request, podes ver o resultado das tuas alterações [neste link](${{ steps.extract_vars.outputs.baseurl }}/${{ steps.extract_vars.outputs.previewpath }}/${{ steps.extract_vars.outputs.pr_number }})"
+            })

--- a/.github/workflows/update_github_pages.yml
+++ b/.github/workflows/update_github_pages.yml
@@ -1,0 +1,21 @@
+name: Publish a preview link to Github Pages on Pull Requests
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: update Github Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          enable_jekyll: true
+          publish_dir: .
+          destination_dir: .
+          keep_files: true


### PR DESCRIPTION
# Github actions for publishing a preview link before merging a pull request.

This action will publish the content on a different branch and comment on the pull request with a link for the new generated content.

You may check this example: https://github.com/tcarreira/ate-onde-chega-cultura/pull/4.  
The bot will comment out a link to a `...prev-link/pr/<#PR>` link


## Important

In order for this to work, the repository maintainer needs to change the source branch at https://github.com/InterruptorPt/ate-onde-chega-cultura/settings/pages to the branch named `gh-pages` like this:
![image](https://user-images.githubusercontent.com/5046551/139259049-57be6f54-bbb3-472c-8c5c-568eede10fbf.png)

(ps: if you do this change before merging the PR, the https://interruptorpt.github.io/ate-onde-chega-cultura/ will fail with 404, but it will be fixed automatically after merging)